### PR TITLE
Fix options not updating in the component when updated from Python

### DIFF
--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
@@ -12,7 +12,6 @@ import FreeTextSelectStyle from "./styling";
 interface State {
   isFocused: boolean
   extended: boolean;
-  options: OptionType[];
   selectedOption: OptionType | null;
   inputOption: String | null;
 }
@@ -29,18 +28,14 @@ class FreeTextSelect extends StreamlitComponentBase<State> {
 
   constructor(props: ComponentProps) {
     super(props);
-    const options = this.props.args.options.map((option: string) => {
-      return { label: option, value: option };
-    })
+    const options = this._getOptionsFromArgs();
     this.state = {
       isFocused: false,
       extended: false,
-      options: options,
       selectedOption: (props.args.index !== null) ? options[props.args.index] : null,
       inputOption: null,
     }
     if (this.state.selectedOption) {
-      console.log("updating component")
       this._updateComponent(this.state.selectedOption);
     }
 
@@ -97,8 +92,14 @@ class FreeTextSelect extends StreamlitComponentBase<State> {
     );
   };
 
+  private _getOptionsFromArgs(): OptionType[] {
+    return this.props.args.options.map((option: string) => {
+      return { label: option, value: option };
+    })
+  }
+
   private _getOptions(): OptionType[] {
-    let options: OptionType[] = [...this.state.options];
+    let options = this._getOptionsFromArgs();
     if (this.state.inputOption !== null) {
       options.unshift({ label: this.state.inputOption, value: this.state.inputOption });
     }


### PR DESCRIPTION
Because the options were only loaded from args when the component was constructed, they would not update when the options argument was changed from Python. This fixes this problem by removing the options from state, and retrieving them directly from args in the render function.

Small app demonstrating the problem:
```python
import streamlit as st 
from streamlit_free_text_select import st_free_text_select

options_count = st.session_state.get('options_counter') or 1
if st.button('Add option'):
    options_count += 1
    st.session_state['options_counter'] = options_count

if st.button('Remove option') and options_count > 1:
    options_count -= 1
    st.session_state['options_counter'] = options_count

options = [f"Option {i}" for i in range(options_count)]

selection = st_free_text_select('test', key='something', options=options)
st.write(f"Selected option: {selection}")
```