### PR TITLE
Add disabled styles support and matching font-family and sizes

### DIFF
--- a/streamlit_free_text_select/streamlit_free_text_select/__init__.py
+++ b/streamlit_free_text_select/streamlit_free_text_select/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional, Literal, Callable
 
 import streamlit.components.v1 as components
 
-_RELEASE = True
+_RELEASE = False
 
 if not _RELEASE:
     _component_func = components.declare_component(

--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/package-lock.json
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/package-lock.json
@@ -1,23 +1,17 @@
 {
   "name": "streamlit-free-text-select",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "streamlit-free-text-select",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
-        "@types/jest": "^24.0.0",
-        "@types/node": "^12.0.0",
-        "@types/react": "^16.9.0",
-        "@types/react-dom": "^16.9.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
-        "react-scripts": "4.0.1",
         "react-select": "^5.7.0",
-        "streamlit-component-lib": "^2.0.0",
-        "typescript": "^4.2.0"
+        "streamlit-component-lib": "^2.0.0"
       },
       "devDependencies": {
         "@types/node": "^12.0.0",
@@ -3998,19 +3992,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/types": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^1.1.1",
-        "@types/yargs": "^13.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -4738,31 +4719,16 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*",
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
-      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
-      "dependencies": {
-        "jest-diff": "^24.3.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -4950,18 +4916,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yargs": {
-      "version": "13.0.12",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
-      "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -5560,14 +5519,6 @@
       ],
       "bin": {
         "ansi-html": "bin/ansi-html"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-styles": {
@@ -7739,14 +7690,6 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
-    },
-    "node_modules/diff-sequences": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -11914,20 +11857,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-diff": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
-      "dependencies": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/jest-docblock": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
@@ -12351,14 +12280,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/jest-haste-map": {
@@ -17540,20 +17461,6 @@
       "dependencies": {
         "lodash": "^4.17.20",
         "renderkid": "^3.0.0"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "dependencies": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/process-nextick-args": {

--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
@@ -63,7 +63,12 @@ class FreeTextSelect extends StreamlitComponentBase<State> {
     return (
       <>
       <LoadGoogleFont/>
-      <div style={this.style.wrapper}>
+      <div
+        style={{
+          ...this.style.wrapper,
+          cursor: this.props.args.disabled ? "not-allowed" : "default",
+        }}
+      >
         {this.props.args.label_visibility !== "collapsed" && (
           <div style={{ visibility: this.props.args.label_visibility }}>
             <label style={this.style.getLabelStyle(this.props.args.disabled)}>

--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import Select from "react-select";
 import {
   ComponentProps,
@@ -8,6 +8,16 @@ import {
 } from "streamlit-component-lib";
 import FreeTextSelectStyle from "./styling";
 
+const LoadGoogleFont = () => {
+  useEffect(() => {
+    const link = document.createElement("link");
+    link.href = "https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap";
+    link.rel = "stylesheet";
+    document.head.appendChild(link);
+  }, []);
+
+  return null;
+};
 
 interface State {
   isFocused: boolean
@@ -51,10 +61,12 @@ class FreeTextSelect extends StreamlitComponentBase<State> {
     const debouncedInputChange = this._debounce(this._handleInputChange, this.props.args.delay);
 
     return (
+      <>
+      <LoadGoogleFont/>
       <div style={this.style.wrapper}>
         {this.props.args.label_visibility !== "collapsed" && (
           <div style={{ visibility: this.props.args.label_visibility }}>
-            <label style={this.style.label}>
+            <label style={this.style.getLabelStyle(this.props.args.disabled)}>
               {this.props.args.label}
             </label>
           </div>
@@ -87,6 +99,7 @@ class FreeTextSelect extends StreamlitComponentBase<State> {
           menuPlacement="auto"
         />
       </div>
+      </>
     );
   };
 

--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/src/FreeTextSelect.tsx
@@ -84,7 +84,7 @@ class FreeTextSelect extends StreamlitComponentBase<State> {
           styles={this.style.select}
           components={{
             ClearIndicator: (props) => this.style.clearIndicator(props),
-            DropdownIndicator: () => this.style.iconDropdown(this.state.extended),
+            DropdownIndicator: () => this.style.iconDropdown(this.state.extended, this.props.args.disabled),
             IndicatorSeparator: () => <div></div>,
           }}
           onChange={(event: any) => { this._handleOnChange(event) }}

--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/src/styling.tsx
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/src/styling.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as Clear } from "./icons/st-clear.svg";
 
 
 // Original code taken from https://github.com/m-wrzr/streamlit-searchbox/blob/main/streamlit_searchbox/frontend/src/Searchbox.tsx
-// Adapted to latest streamlit-1.32.0 style
+// Updated to latest streamlit-1.45.0 style
 
 class FreeTextSelectStyle {
   theme: any;
@@ -23,14 +23,6 @@ class FreeTextSelectStyle {
     this.theme = theme;
     this.wrapper = {
       overflow: "visible",
-    };
-
-    this.label = {
-      color: theme.textColor,
-      fontSize: "12px",
-      fontWeight: 400,
-      font: theme.font,
-      marginBottom: "0.25rem",
     };
 
     this.select = {
@@ -61,45 +53,51 @@ class FreeTextSelectStyle {
         ...styles,
         color: theme.textColor,
       }),
-      //
-      singleValue: (styles: any) => ({
+      singleValue: (styles: any, { isDisabled }: any) => ({
         ...styles,
-        color: theme.textColor,
+        color: isDisabled ? this.theme.fadedText40 : theme.textColor,
       }),
-      placeholder: (styles: any) => ({
+      placeholder: (styles: any, { isDisabled }: any) => ({
         ...styles,
-        color: theme.fadedText60,
+        color: isDisabled ? "#bbb" : theme.fadedText60,
       }),
-      control: (styles: CSSObjectWithLabel, { isFocused }: ControlProps) => {
+      control: (
+        styles: CSSObjectWithLabel, 
+        { isFocused, isDisabled }: ControlProps
+      ) => {
+        const baseBorder = isFocused
+          ? "1px solid " + theme.primaryColor
+          : "1px solid transparent";
+
         return {
           ...styles,
           borderRadius: "0.5rem",
-          backgroundColor: theme.secondaryBackgroundColor,
-          color: theme.secondaryBackgroundColor,
-          border: !isFocused
-            ? "1px transparent"
-            : "1px solid " + theme.primaryColor,
+          backgroundColor: isDisabled
+            ? this.theme.darkenedBgMix15
+            : this.theme.secondaryBackgroundColor,
+          color: isDisabled ? this.theme.fadedText40 : this.theme.textColor,
+          border: baseBorder,
           boxShadow: "none",
+          cursor: isDisabled ? "not-allowed" : "default",
           "&:hover": {
-            border: !isFocused
-              ? "1px transparent"
-              : "1px solid " + theme.primaryColor,
+            border: baseBorder,
           },
           margin: "1px",
         };
       },
       option: (
         styles: CSSObjectWithLabel,
-        { isDisabled, isFocused, isSelected }: OptionProps
-      ) => {
-        return {
-          ...styles,
-          backgroundColor: isDisabled ? undefined
-            : isFocused ? theme.secondaryBackgroundColor : theme.backgroundColor,
-          color: theme.textColor,
-          cursor: isDisabled ? "not-allowed" : "Search ...",
-        };
-      },
+        { isDisabled, isFocused }: OptionProps
+      ) => ({
+        ...styles,
+        backgroundColor: isDisabled
+          ? theme.backgroundColor
+          : isFocused
+          ? theme.secondaryBackgroundColor
+          : theme.backgroundColor,
+        color: isDisabled ? this.theme.fadedText40 : theme.textColor,
+        cursor: isDisabled ? "not-allowed" : "pointer",
+      }),
     };
   }
 
@@ -119,10 +117,24 @@ class FreeTextSelectStyle {
     );
   }
 
+  getLabelStyle(disabled: boolean) {
+    return {
+      color: disabled ? this.theme.fadedText40 : this.theme.textColor, 
+      fontSize: "14px",
+      fontWeight: 400,
+      fontFamily: "'Source Sans Pro', sans-serif",
+      marginBottom: "0.25rem",
+    };
+  }
+
   clearIndicator(props: any) {
     const {
       innerProps: { ref, ...restInnerProps },
+      selectProps,
     } = props;
+
+    // Don't show clear icon if disabled
+    if (selectProps.isDisabled) return null;
 
     return (
       <Clear

--- a/streamlit_free_text_select/streamlit_free_text_select/frontend/src/styling.tsx
+++ b/streamlit_free_text_select/streamlit_free_text_select/frontend/src/styling.tsx
@@ -101,13 +101,18 @@ class FreeTextSelectStyle {
     };
   }
 
-  iconDropdown(menu: boolean) {
+  iconDropdown(menu: boolean, isDisabled: boolean = false) {
+
+    const fillColor = isDisabled
+      ? this.theme.fadedText40
+      : this.theme.textColor;
+
     return (
       <div>
         <Dropdown
           width={24}
           height={24}
-          fill={this.theme.textColor}
+          fill={fillColor}
           style={{
             marginRight: "7px",
             marginBottom: "0px",


### PR DESCRIPTION
Hi @hummerichsander, thanks for creating this great custom component. I have provided some updates that I believe address a few request. 
This PR Closes #7 and Closes #5. I also added a comment on #6 that I believe resolves it. 

Summary of Updates:
- Full Support for `disabled=True,` including greyed-out styles and `not-allowed` cursor
- Adjustments to font-family and font-size to better match Streamlit’s native `st.selectbox` appearance in newest release

Let me know if you'd like me to split any of these changes into separate PRs or add additional tests or documentation.